### PR TITLE
Add prefix to dataframe agent creation

### DIFF
--- a/core/blocks/processing/table/df_agent.py
+++ b/core/blocks/processing/table/df_agent.py
@@ -465,7 +465,8 @@ class PandasDataframeAgentBlock(ProcessingBlock):
                     raise wrap_exception(e, ErrorCode.CONFIG_MISSING, inputs)
 
         # 受け入れ可能なキーワード引数はバージョン差があるため、動的に付与
-        agent_kwargs: Dict[str, Any] = {"verbose": True}
+        prompt_prefix = "Assume 'df' is the dataframe provided and already loaded in the environment."
+        agent_kwargs: Dict[str, Any] = {"verbose": True, "allow_dangerous_code": True, "prefix": prompt_prefix}
         # Try attach callbacks at creation time (version-dependent)
         agent = None
         try:
@@ -474,6 +475,7 @@ class PandasDataframeAgentBlock(ProcessingBlock):
                 dfs_ordered,
                 allow_dangerous_code=True,
                 verbose=True,
+                prefix=prompt_prefix,
                 callbacks=[callback_handler],
                 handle_parsing_errors=True,
             )
@@ -484,6 +486,7 @@ class PandasDataframeAgentBlock(ProcessingBlock):
                     dfs_ordered,
                     allow_dangerous_code=True,
                     verbose=True,
+                    prefix=prompt_prefix,
                     agent_executor_kwargs={
                         "callbacks": [callback_handler],
                         "handle_parsing_errors": True,


### PR DESCRIPTION
Add a predefined prefix to the DataFrame agent creation to inform the agent about the 'df' variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a888db1-9bd4-4aea-9dfe-28c5ae8757ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a888db1-9bd4-4aea-9dfe-28c5ae8757ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

